### PR TITLE
Make CMakeLists.txt depend on collada-dom version 2.4. (#11)

### DIFF
--- a/collada_parser/CMakeLists.txt
+++ b/collada_parser/CMakeLists.txt
@@ -18,7 +18,7 @@ include_directories(include ${catkin_INCLUDE_DIRS} ${urdfdom_headers_INCLUDE_DIR
 
 set(CMAKE_MODULE_PATH  ${PROJECT_SOURCE_DIR}/cmake-extensions/)
 find_package(PkgConfig)
-find_package(COLLADA_DOM 2.3 COMPONENTS 1.5)
+find_package(COLLADA_DOM 2.4 REQUIRED COMPONENTS 1.5)
 if(COLLADA_DOM_FOUND)
   include_directories(${COLLADA_DOM_INCLUDE_DIRS})
   link_directories(${COLLADA_DOM_LIBRARY_DIRS})


### PR DESCRIPTION
This has been the default on Ubuntu forever, so switch to it
here.  While we are at it, also make it a REQUIRED component.

Signed-off-by: Chris Lalancette <clalancette@osrfoundation.org>