### PR TITLE
Collada cleanup dependencies

### DIFF
--- a/collada_parser/CMakeLists.txt
+++ b/collada_parser/CMakeLists.txt
@@ -3,17 +3,10 @@ project(collada_parser)
 
 find_package(Boost REQUIRED system)
 
-find_package(catkin REQUIRED COMPONENTS class_loader rosconsole urdf_parser_plugin urdf)
+find_package(catkin REQUIRED COMPONENTS class_loader rosconsole urdf urdf_parser_plugin)
 find_package(urdfdom_headers REQUIRED)
 
 add_compile_options(-std=c++11)
-
-catkin_package(
-  LIBRARIES ${PROJECT_NAME}
-  INCLUDE_DIRS include
-  CATKIN_DEPENDS rosconsole urdf_parser_plugin
-  DEPENDS urdfdom_headers
-)
 
 include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS} ${urdfdom_headers_INCLUDE_DIRS})
 
@@ -24,6 +17,13 @@ if(COLLADA_DOM_FOUND)
   include_directories(${COLLADA_DOM_INCLUDE_DIRS})
   link_directories(${COLLADA_DOM_LIBRARY_DIRS})
 endif()
+
+catkin_package(
+  LIBRARIES ${PROJECT_NAME}
+  INCLUDE_DIRS include
+  CATKIN_DEPENDS class_loader rosconsole urdf urdf_parser_plugin
+  DEPENDS COLLADA_DOM
+)
 
 # necessary for collada reader to create the temporary dae files due
 # to limitations in the URDF geometry

--- a/collada_parser/CMakeLists.txt
+++ b/collada_parser/CMakeLists.txt
@@ -8,15 +8,14 @@ find_package(urdfdom_headers REQUIRED)
 
 add_compile_options(-std=c++11)
 
-catkin_package( 
+catkin_package(
   LIBRARIES ${PROJECT_NAME}
   INCLUDE_DIRS include
   CATKIN_DEPENDS roscpp urdf_parser_plugin
   DEPENDS urdfdom_headers
 )
 
-include_directories(${Boost_INCLUDE_DIR})
-include_directories(include ${catkin_INCLUDE_DIRS} ${urdfdom_headers_INCLUDE_DIRS})
+include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS} ${urdfdom_headers_INCLUDE_DIRS})
 
 set(CMAKE_MODULE_PATH  ${PROJECT_SOURCE_DIR}/cmake-extensions/)
 find_package(PkgConfig)
@@ -49,7 +48,7 @@ target_link_libraries(${PROJECT_NAME}_plugin
 set_target_properties(${PROJECT_NAME}
   PROPERTIES COMPILER_FLAGS "${COLLADA_DOM_CFLAGS_OTHER}"
 )
-if(APPLE) 
+if(APPLE)
   set_target_properties(${PROJECT_NAME}
     PROPERTIES LINK_FLAGS
     "${COLLADA_DOM_LDFLAGS_OTHER} -undefined dynamic_lookup"

--- a/collada_parser/CMakeLists.txt
+++ b/collada_parser/CMakeLists.txt
@@ -3,7 +3,7 @@ project(collada_parser)
 
 find_package(Boost REQUIRED system)
 
-find_package(catkin REQUIRED COMPONENTS urdf_parser_plugin roscpp class_loader urdf)
+find_package(catkin REQUIRED COMPONENTS class_loader rosconsole urdf_parser_plugin urdf)
 find_package(urdfdom_headers REQUIRED)
 
 add_compile_options(-std=c++11)
@@ -11,7 +11,7 @@ add_compile_options(-std=c++11)
 catkin_package(
   LIBRARIES ${PROJECT_NAME}
   INCLUDE_DIRS include
-  CATKIN_DEPENDS roscpp urdf_parser_plugin
+  CATKIN_DEPENDS rosconsole urdf_parser_plugin
   DEPENDS urdfdom_headers
 )
 

--- a/collada_parser/include/collada_parser/collada_parser.h
+++ b/collada_parser/include/collada_parser/collada_parser.h
@@ -38,16 +38,13 @@
 #define COLLADA_PARSER_COLLADA_PARSER_H
 
 #include <string>
-#include <map>
-#include <boost/function.hpp>
 
 #include <urdf/urdfdom_compatibility.h>
-
 
 namespace urdf {
 
 /// \brief Load Model from string
-urdf::ModelInterfaceSharedPtr parseCollada(const std::string &xml_string );
+urdf::ModelInterfaceSharedPtr parseCollada(const std::string& xml_string);
 
 }
 

--- a/collada_parser/include/collada_parser/collada_parser_plugin.h
+++ b/collada_parser/include/collada_parser/collada_parser_plugin.h
@@ -37,6 +37,8 @@
 #ifndef COLLADA_PARSER_COLLADA_PARSER_PLUGIN_H
 #define COLLADA_PARSER_COLLADA_PARSER_PLUGIN_H
 
+#include <string>
+
 #include <urdf_parser_plugin/parser.h>
 
 namespace urdf
@@ -46,7 +48,7 @@ class ColladaURDFParser : public URDFParser
 {
 public:
 
-  virtual urdf::ModelInterfaceSharedPtr parse(const std::string &xml_string);
+  virtual urdf::ModelInterfaceSharedPtr parse(const std::string& xml_string);
 };
 
 }

--- a/collada_parser/package.xml
+++ b/collada_parser/package.xml
@@ -25,19 +25,18 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_export_depend>urdf</build_export_depend>
+  <build_export_depend>urdf_parser_plugin</build_export_depend>
 
   <build_depend>class_loader</build_depend>
   <build_depend>collada-dom</build_depend>
   <build_depend>liburdfdom-headers-dev</build_depend>
   <build_depend>rosconsole</build_depend>
-  <build_depend>urdf_parser_plugin</build_depend>
   <build_depend>urdf</build_depend>
+  <build_depend>urdf_parser_plugin</build_depend>
 
   <exec_depend>class_loader</exec_depend>
   <exec_depend>collada-dom</exec_depend>
-  <exec_depend>liburdfdom-headers-dev</exec_depend>
   <exec_depend>rosconsole</exec_depend>
-  <exec_depend>urdf_parser_plugin</exec_depend>
 
   <export>
     <urdf_parser_plugin plugin="${prefix}/collada_parser_plugin_description.xml"/>

--- a/collada_parser/package.xml
+++ b/collada_parser/package.xml
@@ -29,14 +29,14 @@
   <build_depend>class_loader</build_depend>
   <build_depend>collada-dom</build_depend>
   <build_depend>liburdfdom-headers-dev</build_depend>
-  <build_depend>roscpp</build_depend>
+  <build_depend>rosconsole</build_depend>
   <build_depend>urdf_parser_plugin</build_depend>
   <build_depend>urdf</build_depend>
 
   <exec_depend>class_loader</exec_depend>
   <exec_depend>collada-dom</exec_depend>
   <exec_depend>liburdfdom-headers-dev</exec_depend>
-  <exec_depend>roscpp</exec_depend>
+  <exec_depend>rosconsole</exec_depend>
   <exec_depend>urdf_parser_plugin</exec_depend>
 
   <export>

--- a/collada_parser/package.xml
+++ b/collada_parser/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>collada_parser</name>
   <version>1.12.10</version>
   <description>
@@ -24,18 +24,20 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_export_depend>urdf</build_export_depend>
+
+  <build_depend>class_loader</build_depend>
   <build_depend>collada-dom</build_depend>
   <build_depend>liburdfdom-headers-dev</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>urdf_parser_plugin</build_depend>
-  <build_depend>class_loader</build_depend>
   <build_depend>urdf</build_depend>
 
-  <run_depend>collada-dom</run_depend>
-  <run_depend>liburdfdom-headers-dev</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>urdf_parser_plugin</run_depend>
-  <run_depend>class_loader</run_depend>
+  <exec_depend>class_loader</exec_depend>
+  <exec_depend>collada-dom</exec_depend>
+  <exec_depend>liburdfdom-headers-dev</exec_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>urdf_parser_plugin</exec_depend>
 
   <export>
     <urdf_parser_plugin plugin="${prefix}/collada_parser_plugin_description.xml"/>

--- a/collada_parser/src/collada_parser.cpp
+++ b/collada_parser/src/collada_parser.cpp
@@ -56,11 +56,13 @@
 #include <dom/domTriangles.h>
 #include <dae/daeStandardURIResolver.h>
 
+#include <boost/array.hpp>
 #include <boost/assert.hpp>
 #include <boost/format.hpp>
+#include <boost/lexical_cast.hpp>
 #include <boost/shared_ptr.hpp>
 
-#include <ros/ros.h>
+#include <ros/console.h>
 #include <collada_parser/collada_parser.h>
 #include <urdf_model/model.h>
 

--- a/collada_parser/src/collada_parser.cpp
+++ b/collada_parser/src/collada_parser.cpp
@@ -70,10 +70,6 @@
 #include <fstream>
 #include <fcntl.h>
 #endif
-#ifndef HAVE_MKSTEMPS
-#include <fstream>
-#include <fcntl.h>
-#endif
 
 #define typeof __typeof__
 #define FOREACH(it, v) for(typeof((v).begin())it = (v).begin(); it != (v).end(); (it)++)

--- a/collada_parser/src/collada_parser.cpp
+++ b/collada_parser/src/collada_parser.cpp
@@ -34,14 +34,13 @@
 
 /* Author: Rosen Diankov, used OpenRAVE files for reference  */
 #include <cmath>
+#include <cstdint>
 #include <cstdlib>
 #include <list>
 #include <map>
 #include <string>
 #include <sstream>
 #include <vector>
-
-#include <stdint.h>
 
 /* disable deprecated auto_ptr warnings */
 #pragma GCC diagnostic push

--- a/collada_parser/src/collada_parser.cpp
+++ b/collada_parser/src/collada_parser.cpp
@@ -33,14 +33,15 @@
 *********************************************************************/
 
 /* Author: Rosen Diankov, used OpenRAVE files for reference  */
-#include <vector>
+#include <cmath>
+#include <cstdlib>
 #include <list>
 #include <map>
-#include <stdint.h>
-#include <cstdlib>
-#include <cmath>
 #include <string>
 #include <sstream>
+#include <vector>
+
+#include <stdint.h>
 
 /* disable deprecated auto_ptr warnings */
 #pragma GCC diagnostic push

--- a/collada_parser/src/collada_parser_plugin.cpp
+++ b/collada_parser/src/collada_parser_plugin.cpp
@@ -36,7 +36,7 @@
 
 #include "collada_parser/collada_parser_plugin.h"
 #include "collada_parser/collada_parser.h"
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 
 urdf::ModelInterfaceSharedPtr urdf::ColladaURDFParser::parse(const std::string &xml_string)
 {

--- a/collada_urdf/CMakeLists.txt
+++ b/collada_urdf/CMakeLists.txt
@@ -3,10 +3,7 @@ project(collada_urdf)
 
 find_package(catkin REQUIRED COMPONENTS angles cmake_modules collada_parser geometric_shapes resource_retriever rosconsole urdf)
 
-catkin_package(
-  LIBRARIES ${PROJECT_NAME}
-  INCLUDE_DIRS include
-  DEPENDS angles collada_parser geometric_shapes resource_retriever rosconsole urdf)
+find_package(urdfdom_headers REQUIRED)
 
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag(-std=c++11 HAS_STD_CPP11_FLAG)
@@ -55,6 +52,13 @@ if( COLLADA_DOM_FOUND )
   include_directories(${COLLADA_DOM_INCLUDE_DIRS})
   link_directories(${COLLADA_DOM_LIBRARY_DIRS})
 endif()
+
+catkin_package(
+  LIBRARIES ${PROJECT_NAME}
+  INCLUDE_DIRS include
+  CATKIN_DEPENDS collada_parser geometric_shapes resource_retriever rosconsole urdf
+  DEPENDS ASSIMP COLLADA_DOM urdfdom_headers
+)
 
 include_directories(${catkin_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})

--- a/collada_urdf/CMakeLists.txt
+++ b/collada_urdf/CMakeLists.txt
@@ -1,12 +1,12 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(collada_urdf)
 
-find_package(catkin REQUIRED COMPONENTS angles collada_parser resource_retriever urdf geometric_shapes cmake_modules)
+find_package(catkin REQUIRED COMPONENTS angles cmake_modules collada_parser geometric_shapes resource_retriever urdf)
 
 catkin_package(
   LIBRARIES ${PROJECT_NAME}
   INCLUDE_DIRS include
-  DEPENDS angles collada_parser resource_retriever urdf geometric_shapes)
+  DEPENDS angles collada_parser geometric_shapes resource_retriever urdf)
 
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag(-std=c++11 HAS_STD_CPP11_FLAG)

--- a/collada_urdf/CMakeLists.txt
+++ b/collada_urdf/CMakeLists.txt
@@ -1,12 +1,12 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(collada_urdf)
 
-find_package(catkin REQUIRED COMPONENTS angles cmake_modules collada_parser geometric_shapes resource_retriever urdf)
+find_package(catkin REQUIRED COMPONENTS angles cmake_modules collada_parser geometric_shapes resource_retriever rosconsole urdf)
 
 catkin_package(
   LIBRARIES ${PROJECT_NAME}
   INCLUDE_DIRS include
-  DEPENDS angles collada_parser geometric_shapes resource_retriever urdf)
+  DEPENDS angles collada_parser geometric_shapes resource_retriever rosconsole urdf)
 
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag(-std=c++11 HAS_STD_CPP11_FLAG)

--- a/collada_urdf/include/collada_urdf/collada_urdf.h
+++ b/collada_urdf/include/collada_urdf/collada_urdf.h
@@ -1,13 +1,13 @@
 /*********************************************************************
 * Software License Agreement (BSD License)
-* 
+*
 *  Copyright (c) 2010, Willow Garage, Inc.
 *  All rights reserved.
-* 
+*
 *  Redistribution and use in source and binary forms, with or without
 *  modification, are permitted provided that the following conditions
 *  are met:
-* 
+*
 *   * Redstributions of source code must retain the above copyright
 *     notice, this list of conditions and the following disclaimer.
 *   * Redistributions in binary form must reproduce the above
@@ -17,7 +17,7 @@
 *   * Neither the name of the Willow Garage nor the names of its
 *     contributors may be used to endorse or promote products derived
 *     from this software without specific prior written permission.
-* 
+*
 *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -37,15 +37,8 @@
 #ifndef COLLADA_URDF_COLLADA_URDF_H
 #define COLLADA_URDF_COLLADA_URDF_H
 
+#include <stdexcept>
 #include <string>
-#include <boost/shared_ptr.hpp>
-
-#ifndef _WIN32
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#include <dae.h>
-#pragma GCC diagnostic pop
-#endif
 
 #include "urdf/model.h"
 

--- a/collada_urdf/package.xml
+++ b/collada_urdf/package.xml
@@ -23,6 +23,8 @@
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
+  <build_export_depend>liburdfdom-headers-dev</build_export_depend>
+
   <build_depend>angles</build_depend>
   <build_depend>assimp-dev</build_depend>
   <build_depend>cmake_modules</build_depend>
@@ -36,13 +38,11 @@
   <build_depend>rosconsole</build_depend>
   <build_depend>urdf</build_depend>
 
-  <exec_depend>angles</exec_depend>
   <exec_depend>assimp</exec_depend>
   <exec_depend>collada-dom</exec_depend>
   <exec_depend>collada_parser</exec_depend>
   <exec_depend>geometric_shapes</exec_depend>
   <exec_depend>liburdfdom-dev</exec_depend>
-  <exec_depend>liburdfdom-headers-dev</exec_depend>
   <exec_depend>resource_retriever</exec_depend>
   <exec_depend>rosconsole</exec_depend>
   <exec_depend>urdf</exec_depend>

--- a/collada_urdf/package.xml
+++ b/collada_urdf/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>collada_urdf</name>
   <version>1.12.10</version>
   <description>
@@ -25,26 +25,26 @@
 
   <build_depend>angles</build_depend>
   <build_depend>assimp-dev</build_depend>
-  <build_depend>resource_retriever</build_depend>
+  <build_depend>cmake_modules</build_depend>
   <build_depend>collada-dom</build_depend>
   <build_depend>collada_parser</build_depend>
+  <build_depend>eigen</build_depend>
+  <build_depend>geometric_shapes</build_depend>
   <build_depend>liburdfdom-dev</build_depend>
   <build_depend>liburdfdom-headers-dev</build_depend>
+  <build_depend>resource_retriever</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>urdf</build_depend>
-  <build_depend>geometric_shapes</build_depend>
-  <build_depend>cmake_modules</build_depend>
-  <build_depend>eigen</build_depend>
 
-  <run_depend>angles</run_depend>
-  <run_depend>assimp</run_depend>
-  <run_depend>collada-dom</run_depend>
-  <run_depend>collada_parser</run_depend>
-  <run_depend>liburdfdom-dev</run_depend>
-  <run_depend>liburdfdom-headers-dev</run_depend>
-  <run_depend>resource_retriever</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>urdf</run_depend>
-  <run_depend>geometric_shapes</run_depend>
+  <exec_depend>angles</exec_depend>
+  <exec_depend>assimp</exec_depend>
+  <exec_depend>collada-dom</exec_depend>
+  <exec_depend>collada_parser</exec_depend>
+  <exec_depend>geometric_shapes</exec_depend>
+  <exec_depend>liburdfdom-dev</exec_depend>
+  <exec_depend>liburdfdom-headers-dev</exec_depend>
+  <exec_depend>resource_retriever</exec_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>urdf</exec_depend>
 
 </package>

--- a/collada_urdf/package.xml
+++ b/collada_urdf/package.xml
@@ -33,7 +33,7 @@
   <build_depend>liburdfdom-dev</build_depend>
   <build_depend>liburdfdom-headers-dev</build_depend>
   <build_depend>resource_retriever</build_depend>
-  <build_depend>roscpp</build_depend>
+  <build_depend>rosconsole</build_depend>
   <build_depend>urdf</build_depend>
 
   <exec_depend>angles</exec_depend>
@@ -44,7 +44,7 @@
   <exec_depend>liburdfdom-dev</exec_depend>
   <exec_depend>liburdfdom-headers-dev</exec_depend>
   <exec_depend>resource_retriever</exec_depend>
-  <exec_depend>roscpp</exec_depend>
+  <exec_depend>rosconsole</exec_depend>
   <exec_depend>urdf</exec_depend>
 
 </package>

--- a/collada_urdf/src/collada_to_urdf.cpp
+++ b/collada_urdf/src/collada_to_urdf.cpp
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#include <ros/ros.h>
+#include <ros/console.h>
 #include <urdf/model.h>
 
 #include <collada_parser/collada_parser.h>

--- a/collada_urdf/src/collada_to_urdf.cpp
+++ b/collada_urdf/src/collada_to_urdf.cpp
@@ -1,4 +1,10 @@
 /* Author: Yohei Kakiuchi */
+
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <vector>
+
 #include <ros/ros.h>
 #include <urdf/model.h>
 
@@ -20,9 +26,6 @@
 #include <aiScene.h>
 #include <aiPostProcess.h>
 #endif
-
-#include <iostream>
-#include <fstream>
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem/path.hpp>

--- a/collada_urdf/src/collada_urdf.cpp
+++ b/collada_urdf/src/collada_urdf.cpp
@@ -36,9 +36,11 @@
 /* Authors: Rosen Diankov, Tim Field */
 
 #include "collada_urdf/collada_urdf.h"
-#include <map>
-#include <vector>
+
 #include <list>
+#include <map>
+#include <string>
+#include <vector>
 
 #ifndef _WIN32
 #pragma GCC diagnostic push

--- a/collada_urdf/src/urdf_to_collada.cpp
+++ b/collada_urdf/src/urdf_to_collada.cpp
@@ -48,7 +48,7 @@ int main(int argc, char** argv)
 
     urdf::Model robot_model;
     if (!robot_model.initFile(input_filename)) {
-        ROS_ERROR("failed to open urdf file %s", input_filename.c_str());
+        std::cerr << "failed to open urdf file " << input_filename << std::endl;
         return -2;
     }
 

--- a/collada_urdf/src/urdf_to_collada.cpp
+++ b/collada_urdf/src/urdf_to_collada.cpp
@@ -34,14 +34,7 @@
 
 /* Author: Tim Field */
 
-#ifndef _WIN32
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include "collada_urdf/collada_urdf.h"
-#pragma GCC diagnostic pop
-#endif
-
-#include <ros/ros.h>
 
 int main(int argc, char** argv)
 {
@@ -50,13 +43,11 @@ int main(int argc, char** argv)
         return -1;
     }
 
-    ros::init(argc, argv, "urdf_to_collada");
-
     std::string input_filename(argv[1]);
     std::string output_filename(argv[2]);
 
     urdf::Model robot_model;
-    if( !robot_model.initFile(input_filename) ) {
+    if (!robot_model.initFile(input_filename)) {
         ROS_ERROR("failed to open urdf file %s", input_filename.c_str());
         return -2;
     }

--- a/collada_urdf/test/test_collada_urdf.cpp
+++ b/collada_urdf/test/test_collada_urdf.cpp
@@ -31,10 +31,6 @@
 
 #include <gtest/gtest.h>
 
-#include <fstream>
-#include <sstream>
-#include <string>
-
 TEST(collada_urdf, collada_from_urdf_file_works)
 {
     urdf::Model robot_model;
@@ -51,7 +47,8 @@ TEST(collada_urdf, collada_output_dir_does_not_exist)
     ASSERT_FALSE(collada_urdf::WriteUrdfModelToColladaFile(robot_model, "a/very/long/directory/path/that/should/not/exist/pr2.dae"));
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
This PR cleans up collada to setup the dependencies more properly, and do some other cleanup.  More specifically:

1.  It switches both packages in the repository to package format 2.
1.  It cleans out unnecessary includes from the header files.
1.  It changes from including `class_loader.h` to `class_loader.hpp`, as the former is deprecated.
1.  It removes all dependencies from this package to roscpp; only rosconsole is really needed.
1.  It fixes up the dependencies in the package.xml and CMakeLists.txt to properly export dependencies to downstream users, and bring in the correct dependencies everywhere.