### PR TITLE
add exec_depend to package.xml of collada_parser for loading by pluginlib

### DIFF
--- a/collada_parser/package.xml
+++ b/collada_parser/package.xml
@@ -37,6 +37,7 @@
   <exec_depend>class_loader</exec_depend>
   <exec_depend>collada-dom</exec_depend>
   <exec_depend>rosconsole</exec_depend>
+  <exec_depend>urdf_parser_plugin</exec_depend>
 
   <export>
     <urdf_parser_plugin plugin="${prefix}/collada_parser_plugin_description.xml"/>


### PR DESCRIPTION
In https://github.com/ros/collada_urdf/pull/26
package.xml was converted to format 2.
We need to add ```<exec_depend>urdf_parser_plugin</exec_depend>``` for loading by pluginlib.

I checked it with command below.
```
rospack plugins --attrib=plugin urdf_parser_plugin
```