### PR TITLE
support multi visual tags

### DIFF
--- a/collada_urdf/src/collada_urdf.cpp
+++ b/collada_urdf/src/collada_urdf.cpp
@@ -1176,13 +1176,8 @@ protected:
                         string geomid = _ComputeId(str(boost::format("g%s_%s_geom%d")%strModelUri%linksid%igeom));
                         igeom++;
                         domGeometryRef pdomgeom;
-                        if ( it != plink->visual_array.begin() ) {
-                            urdf::Pose org_trans =  _poseMult(geometry_origin_inv, (*it)->origin);
-                            pdomgeom = _WriteGeometry((*it)->geometry, geomid, &org_trans);
-                        }
-                        else {
-                            pdomgeom = _WriteGeometry((*it)->geometry, geomid);
-                        }
+                        urdf::Pose org_trans =  _poseMult(geometry_origin_inv, (*it)->origin);
+                        pdomgeom = _WriteGeometry((*it)->geometry, geomid, &org_trans);
                         domInstance_geometryRef pinstgeom = daeSafeCast<domInstance_geometry>(pnode->add(COLLADA_ELEMENT_INSTANCE_GEOMETRY));
                         pinstgeom->setUrl((string("#") + geomid).c_str());
                         // material
@@ -1293,7 +1288,7 @@ protected:
         case urdf::Geometry::SPHERE: {
             shapes::Sphere sphere(static_cast<urdf::Sphere*>(geometry.get())->radius);
             boost::scoped_ptr<shapes::Mesh> mesh(shapes::createMeshFromShape(sphere));
-            _loadVertices(mesh.get(), cgeometry);
+            _loadVertices(mesh.get(), cgeometry, org_trans);
             break;
         }
         case urdf::Geometry::BOX: {
@@ -1301,14 +1296,14 @@ protected:
                             static_cast<urdf::Box*>(geometry.get())->dim.y,
                             static_cast<urdf::Box*>(geometry.get())->dim.z);
             boost::scoped_ptr<shapes::Mesh> mesh(shapes::createMeshFromShape(box));
-            _loadVertices(mesh.get(), cgeometry);
+            _loadVertices(mesh.get(), cgeometry, org_trans);
             break;
         }
         case urdf::Geometry::CYLINDER: {
             shapes::Cylinder cyl(static_cast<urdf::Cylinder*>(geometry.get())->radius,
                                  static_cast<urdf::Cylinder*>(geometry.get())->length);
             boost::scoped_ptr<shapes::Mesh> mesh(shapes::createMeshFromShape(cyl));
-            _loadVertices(mesh.get(), cgeometry);
+            _loadVertices(mesh.get(), cgeometry, org_trans);
             break;
         }
         default: {
@@ -1437,7 +1432,7 @@ protected:
         return pmout;
     }
 
-    void _loadVertices(const shapes::Mesh *mesh, domGeometryRef pdomgeom) {
+    void _loadVertices(const shapes::Mesh *mesh, domGeometryRef pdomgeom, urdf::Pose *org_trans) {
 
         // convert the mesh into an STL binary (in memory)
         std::vector<char> buffer;
@@ -1486,7 +1481,7 @@ protected:
             pvertinput->setSemantic("POSITION");
             pvertinput->setSource(domUrifragment(*pvertsource, std::string("#")+std::string(pvertsource->getID())));
         }
-        _buildAiMesh(scene,scene->mRootNode,pdommesh,parray, pdomgeom->getID(), urdf::Vector3(1,1,1));
+        _buildAiMesh(scene,scene->mRootNode,pdommesh,parray, pdomgeom->getID(), urdf::Vector3(1,1,1), org_trans);
         pacc->setCount(parray->getCount());
     }
 


### PR DESCRIPTION
cc @YoheiKakiuchi (original comitter of this part https://github.com/ros/robot_model/pull/20)

I am a ``urdf_to_collada`` user which converts URDF to COLLADA, and it seems that the original URDF file and the generated COLLADA are different when it has multi visual tags.

Let's say we have the following URDF file ``test.urdf``.
```xml
<?xml version="1.0"?>
<robot xmlns:xacro="http://ros.org/wiki/xacro" name="test" >
  <link name="base_link" />

  <joint name="test_joint_1" type="fixed">
    <parent link="base_link"/>
    <child link = "link1"/>
  </joint>

  <link name="link1">
    <visual>
      <origin xyz="0 0 0" rpy="0 0 0"/>
      <geometry>
        <box size="0.5 0.5 0.3"/>
      </geometry>
      <material name="Cyan">
        <color rgba="0 1 1 1"/>
      </material>
    </visual>
    <visual>
      <origin xyz="0 0 0.2" rpy="1.57 0 0"/>
      <geometry>
        <box size="0.1 1.0 0.1"/>
      </geometry>
      <material name="White">
        <color rgba="1 1 1 1"/>
      </material>
    </visual>
  </link>
</robot>
```

| original URDF| COLLADA w/o this PR | COLLADA w/ this PR |
| --- | --- | --- |
| ![image](https://user-images.githubusercontent.com/4509039/49698056-11965880-fc02-11e8-874d-2bf5056e7253.png) | ![image](https://user-images.githubusercontent.com/4509039/49698027-c1b79180-fc01-11e8-979d-e8b67c53731b.png) | ![image](https://user-images.githubusercontent.com/4509039/49698039-e449aa80-fc01-11e8-8af1-045cce5260ab.png) |
| ``roslaunch urdf_tutorial display.launch model:=test.urdf`` | ``rosrun collada_urdf urdf_to_collada test.urdf test.dae && roslaunch urdf_tutorial display.launch model:=test.dae`` | ``rosrun collada_urdf urdf_to_collada test.urdf test.dae && roslaunch urdf_tutorial display.launch model:=test.dae``  |