### PR TITLE
Update to newer CMake to get rid of CMP0048 warning

### DIFF
--- a/collada_parser/CMakeLists.txt
+++ b/collada_parser/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(collada_parser)
 
 find_package(Boost REQUIRED system)

--- a/collada_urdf/CMakeLists.txt
+++ b/collada_urdf/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.0.2)
 project(collada_urdf)
 
 find_package(catkin REQUIRED COMPONENTS angles cmake_modules collada_parser geometric_shapes resource_retriever rosconsole urdf)


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

@k-okada FYI