### PR TITLE
[ROS-O] Drop CXX standards logcxx patch

### DIFF
--- a/collada_parser/CMakeLists.txt
+++ b/collada_parser/CMakeLists.txt
@@ -6,8 +6,6 @@ find_package(Boost REQUIRED system)
 find_package(catkin REQUIRED COMPONENTS class_loader rosconsole urdf urdf_parser_plugin)
 find_package(urdfdom_headers REQUIRED)
 
-add_compile_options(-std=c++11)
-
 include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS} ${urdfdom_headers_INCLUDE_DIRS})
 
 set(CMAKE_MODULE_PATH  ${PROJECT_SOURCE_DIR}/cmake-extensions/)

--- a/collada_urdf/CMakeLists.txt
+++ b/collada_urdf/CMakeLists.txt
@@ -6,10 +6,6 @@ find_package(catkin REQUIRED COMPONENTS angles cmake_modules collada_parser geom
 find_package(urdfdom_headers REQUIRED)
 
 include(CheckCXXCompilerFlag)
-check_cxx_compiler_flag(-std=c++11 HAS_STD_CPP11_FLAG)
-if(HAS_STD_CPP11_FLAG)
-  add_compile_options(-std=c++11)
-endif()
 
 include_directories(include)
 


### PR DESCRIPTION
required to build on Ubuntu 22.04 and upwards.